### PR TITLE
Fix references to old integration

### DIFF
--- a/custom_components/daily/__init__.py
+++ b/custom_components/daily/__init__.py
@@ -1,4 +1,4 @@
-"""The Smart Irrigation integration."""
+"""The Daily Sensor integration."""
 import asyncio
 from datetime import timedelta
 import logging

--- a/custom_components/daily/config_flow.py
+++ b/custom_components/daily/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Smart Irrigation integration."""
+"""Config flow for Daily Sensor integration."""
 from .const import (  # pylint: disable=unused-import
     DOMAIN,
     CONF_INPUT_SENSOR,

--- a/custom_components/daily/entity.py
+++ b/custom_components/daily/entity.py
@@ -1,4 +1,4 @@
-"""SmartIrrigationEntity class."""
+"""Daily Sensor class."""
 from homeassistant.helpers.restore_state import RestoreEntity
 import logging
 

--- a/custom_components/daily/sensor.py
+++ b/custom_components/daily/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for Smart Irrigation."""
+"""Sensor platform for Daily Sensor."""
 import asyncio
 import logging
 from statistics import median, stdev, variance, StatisticsError

--- a/custom_components/daily/strings.json
+++ b/custom_components/daily/strings.json
@@ -22,7 +22,6 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "single_instance_allowed": "Only a single configuration of Smart Irrigation is allowed."
     }
   }
 }

--- a/custom_components/daily/translations/en.json
+++ b/custom_components/daily/translations/en.json
@@ -22,7 +22,6 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "single_instance_allowed": "Only a single configuration of Smart Irrigation is allowed."
     }
   }
 }


### PR DESCRIPTION
Changed references from Smart Integration to Daily Sensor.
Also removed abort messages that I believe are no longer used from translation and string files.
I left the `abort` tag for future use - but am not sure if this would cause an issue since it is empty.