### PR TITLE
Round mean operation to one decimal place

### DIFF
--- a/custom_components/daily/sensor.py
+++ b/custom_components/daily/sensor.py
@@ -109,7 +109,7 @@ class DailySensor(DailySensorEntity):
                         self._state = the_val
                 elif self.coordinator.operation == CONF_MEAN:
                     self._values.append(the_val)
-                    self._state = (sum(self._values) * 1.0) / len(self._values)
+                    self._state = round((sum(self._values) * 1.0) / len(self._values), 1)
                 elif self.coordinator.operation == CONF_MEDIAN:
                     self._values.append(the_val)
                     self._state = median(self._values)


### PR DESCRIPTION
When mean is selected the returned state has quite many decimal places.
Before
![2](https://user-images.githubusercontent.com/20832276/86457421-edd6be00-bd23-11ea-9dac-48f428c2a8fb.jpg)
After
![1](https://user-images.githubusercontent.com/20832276/86457419-ed3e2780-bd23-11ea-8716-77e0e9b38a8b.jpg)