### PR TITLE
Optionally disable automatic reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Install the custom component (preferably using HACS) and then use the Configurat
 - Name of the input sensor - this is the sensor that the daily sensor will aggregate during the day.
 - The aggregation to run on the input sensor - you can choose min, max, sum, mean, median, stdev and variation.
 - The interval in minutes in which to update this sensor.
+- Automatic reset at midnight ? By default selected, but can be deselected to allow manual reset
 
 That's all. You can add the component multiple times to aggregate other sensors. All sensors will be reset at 00:00 local time and can be reset manually by calling the `reset` service for each instance of the component.
 

--- a/custom_components/daily/config_flow.py
+++ b/custom_components/daily/config_flow.py
@@ -6,9 +6,11 @@ from .const import (  # pylint: disable=unused-import
     CONF_NAME,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_INTERVAL,
+    CONF_AUTO_RESET,
     NAME,
     VALID_OPERATIONS,
     DEFAULT_INTERVAL,
+    DEFAULT_AUTO_RESET,
 )
 
 import logging
@@ -32,6 +34,7 @@ class DailySensorConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._input_sensor = ""
         self._unit_of_measurement = "unknown"
         self._errors = {}
+        self._auto_reset = DEFAULT_AUTO_RESET
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
@@ -56,6 +59,7 @@ class DailySensorConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ):
                     raise IntervalNotValid
                 self._name = user_input[CONF_NAME]
+                self._auto_reset = user_input[CONF_AUTO_RESET]
 
                 return self.async_create_entry(title=self._name, data=user_input)
 
@@ -96,6 +100,7 @@ class DailySensorConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_OPERATION): vol.In(VALID_OPERATIONS),
                     vol.Required(CONF_UNIT_OF_MEASUREMENT): str,
                     vol.Required(CONF_INTERVAL, default=DEFAULT_INTERVAL): int,
+                    vol.Required(CONF_AUTO_RESET, default=DEFAULT_AUTO_RESET): bool,
                 }
             ),
             errors=self._errors,

--- a/custom_components/daily/const.py
+++ b/custom_components/daily/const.py
@@ -20,6 +20,7 @@ CONF_OPERATION = "operation"
 CONF_NAME = "name"
 CONF_INTERVAL = "interval"
 CONF_UNIT_OF_MEASUREMENT = "unit_of_measurement"
+CONF_AUTO_RESET = "auto_reset"
 
 # Operations
 CONF_MAX = "max"
@@ -41,7 +42,7 @@ VALID_OPERATIONS = [
 
 # Defaults
 DEFAULT_INTERVAL = 30  # minutes
-
+DEFAULT_AUTO_RESET = True
 # Services
 SERVICE_RESET = "reset"
 SERVICE_UPDATE = "update"

--- a/custom_components/daily/sensor.py
+++ b/custom_components/daily/sensor.py
@@ -23,6 +23,7 @@ from .const import (  # pylint: disable=unused-import
     CONF_OPERATION,
     CONF_INTERVAL,
     CONF_UNIT_OF_MEASUREMENT,
+    CONF_AUTO_RESET,
 )
 from .entity import DailySensorEntity
 
@@ -157,6 +158,7 @@ class DailySensor(DailySensorEntity):
             CONF_OPERATION: self.coordinator.operation,
             CONF_INTERVAL: self.coordinator.interval,
             CONF_UNIT_OF_MEASUREMENT: self.unit_of_measurement,
+            CONF_AUTO_RESET: self.coordinator.auto_reset,
         }
 
     @property

--- a/custom_components/daily/strings.json
+++ b/custom_components/daily/strings.json
@@ -10,7 +10,8 @@
           "sensor": "The entity that will provide input to the daily sensor",
           "operation": "The operation to be applied to the sensor",
           "unit_of_measurement": "The unit of measurement",
-          "interval": "Refresh interval in minutes"
+          "interval": "Refresh interval in minutes",
+          "auto_reset": "Automatically reset at 00:00 ?"
         }
       }
     },

--- a/custom_components/daily/translations/en.json
+++ b/custom_components/daily/translations/en.json
@@ -10,7 +10,8 @@
           "sensor": "The entity that will provide input to the daily sensor",
           "operation": "The operation to be applied to the sensor",
           "unit_of_measurement": "The unit of measurement",
-          "interval": "Refresh interval in minutes"
+          "interval": "Refresh interval in minutes",
+          "auto_reset": "Automatically reset at 00:00"
         }
       }
     },

--- a/custom_components/daily/translations/fr.json
+++ b/custom_components/daily/translations/fr.json
@@ -11,6 +11,7 @@
             "operation": "L'opération à appliquer au capteur",
             "unit_of_measurement": "L'unité de mesure",
             "interval": "L'intervalle de mise à jour en minutes",
+            "auto_reset": "Reset automatique à minuit ?"
           }
         }
       },

--- a/custom_components/daily/translations/nb.json
+++ b/custom_components/daily/translations/nb.json
@@ -10,7 +10,8 @@
           "sensor": "Enheten som vil gi innspill til den daglige sensoren",
           "operation": "Operasjonen som skal brukes på sensoren",
           "unit_of_measurement": "Måleenheten",
-          "interval": "Oppdater intervall i minutter"
+          "interval": "Oppdater intervall i minutter",
+          "auto_reset": "Återställs automatiskt vid midnatt?"
         }
       }
     },


### PR DESCRIPTION
As you already know, I use your nice HADailySensor with your awesome smart irrigation integration.

Forgive me if I am wrong, but I somehow had the issue that sensor is reset at midnight, whereas the smart irrigation reset_bucket service can be called whenever the user wants, ie at something like 9pm (when she is awake and fully operational 👍 for instance). 
In this case, this means that precipitation sensor had aggregated only 21 hours of data (instead of the expected 23/24 hours of aggregated data). So this is less than optimal.

This commits allows scripts or automations to be able to reset sensor aggregations at convenient times by calling the reset service, instead of basing their behaviour on the automatic reset at midnight.

I understand that the HADailySensor is _supposed_ to be .... daily: this option kind of disables this behaviour (the automatic daily behaviour), but by default, the automatic reset is still enabled, on purpose.

Hoping this could help someone,

PS: the norwegian translation is included but it is computer generated.