### PR TITLE
Fix #17

### DIFF
--- a/custom_components/daily/__init__.py
+++ b/custom_components/daily/__init__.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_INTERVAL,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_AUTO_RESET,
+    DEFAULT_AUTO_RESET,
     EVENT_RESET,
     EVENT_UPDATE,
     SERVICE_RESET,
@@ -44,7 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     operation = entry.data.get(CONF_OPERATION)
     interval = entry.data.get(CONF_INTERVAL)
     unit_of_measurement = entry.data.get(CONF_UNIT_OF_MEASUREMENT)
-    auto_reset = entry.data.get(CONF_AUTO_RESET)
+    auto_reset = entry.data.get(CONF_AUTO_RESET, DEFAULT_AUTO_RESET)
 
     # set up coordinator
     coordinator = DailySensorUpdateCoordinator(


### PR DESCRIPTION
This should (a little less assertive in case I missed something again :slightly_smiling_face:) fix the issue of existing configurations not declaring auto_reset option.
The issue came from the auto_reset being set to None if auto_reset key was not in the config entry data mapping.