### PR TITLE
Enable dynamic configuration updates for DailySensor

### DIFF
--- a/custom_components/daily/__init__.py
+++ b/custom_components/daily/__init__.py
@@ -44,6 +44,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if hass.data.get(DOMAIN) is None:
         hass.data.setdefault(DOMAIN, {})
         _LOGGER.info(STARTUP_MESSAGE)
+    if entry.entry_id in hass.data[DOMAIN]:
+        _LOGGER.warning(f"Sensor '{entry.title}' already set up. Updating config dynamically.")
+        existing_data = hass.data[DOMAIN][entry.entry_id]
+        existing_entity = existing_data.get("entity")
+        if existing_entity:
+            await existing_entity.async_update_config(entry.data)
+        return True
     name = entry.data.get(CONF_NAME)
     name_no_spaces_but_underscores = name.replace(" ", "_")
     input_sensor = entry.data.get(CONF_INPUT_SENSOR)

--- a/custom_components/daily/entity.py
+++ b/custom_components/daily/entity.py
@@ -38,3 +38,12 @@ class DailySensorEntity(RestoreEntity):
     async def async_update(self):
         """Update Coordinator entity."""
         await self.coordinator.async_request_refresh()
+
+    async def async_update_config(self, new_config):
+        self._name = new_config.get("name", self._name)
+        self._input_entity_id = new_config.get("input_sensor", self._input_entity_id)
+        self._operation = new_config.get("operation", self._operation)
+        self._interval = new_config.get("interval", self._interval)
+        self._unit_of_measurement = new_config.get("unit_of_measurement", self._unit_of_measurement)
+        self._auto_reset = new_config.get("auto_reset", self._auto_reset)
+        await self.async_update_ha_state()


### PR DESCRIPTION
This PR enables updating existing sensors without causing Home Assistant to crash due to duplicate setup.
Existing entities now support dynamic config updates via async_update_config().